### PR TITLE
fix: le projet ne marche pas entre plusieurs machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Le terminal d'où sera lancée la commande sera bloquée tant que le websocket e
 
 Placez-vous dans le répertoire/ **/websocket_buzzer/webserver** et lancez le web server avec la commande :
 ```bash
-flask run
+flask run --host=0.0.0.0
 ```
 Il devrait être écrit dans le terminal le port ainsi que l'ip du serveur web.
 

--- a/websocket_buzzer/webserver/static/main.js
+++ b/websocket_buzzer/webserver/static/main.js
@@ -80,7 +80,7 @@ function timer(setter) {
 }
 
 window.addEventListener("DOMContentLoaded", () => {
-  const websocket = new WebSocket("ws://localhost:8081/");
+  const websocket = new WebSocket("ws://" + window.location.hostname + ":8081/");
   globalThis.websocket = websocket;
   initWebSocket(websocket);
   receiveMsg(websocket);


### PR DESCRIPTION
Le projet ne marche pas si on utilise plusieurs machines. Cette P.R a pour but de corriger les problèmes suivant :

problème 1: la commande dans le readme pour lancer flask est incorrecte. il faut utiliser `flask run --host=0.0.0.0`

problème 2: l'adresse de la websocket est hard-codée à "localhost:8081". Cette P.R remplace localhost par le hostname récupéré depuis l'url